### PR TITLE
streams v3 compat & add readable-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "transduce": "^0.8.0",
     "transducers-js": "^0.4.158",
     "transducers.js": "^0.3.1"
+  },
+  "dependencies": {
+    "readable-stream": "^2.3.5"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -7,8 +7,10 @@ var stream = require('../'),
     transduce = require('any-transduce'),
     test = require('tape')
 
-function readArray(source){
-  var read = new Readable()
+
+function readArray(_source){
+  var source = _source.concat(null),
+      read = new Readable()
   read._read = function(){
       read.push(source.shift())
   }

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 "use strict"
 var stream = require('../'),
-    Readable = require('stream').Readable,
-    Writable = require('stream').Writable,
+    Readable = require('readable-stream').Readable,
+    Writable = require('readable-stream').Writable,
     string = require('transduce/string'),
     tap = require('transduce/transducers/tap'),
     transduce = require('any-transduce'),

--- a/transduce-stream.js
+++ b/transduce-stream.js
@@ -1,6 +1,6 @@
 "use strict"
 var util = require('util'),
-    Transform = require('stream').Transform
+    Transform = require('readable-stream').Transform
 
 module.exports = TransduceStream
 


### PR DESCRIPTION
Fixes #2 

Updated the `readArray` method to append `null` to the end of the source array. This closes the source stream, allowing tests to pass in the streams v3 API (node 0.12+).

Proceeded to swap out the reliance on the core `stream` module for `readable-stream` - this will lock the steams API in use to a stable implementation so it will work across node versions (both forward *and* back - tested as far back as node 0.10.48) even if the streams API undergoes further changes.